### PR TITLE
Remove argparse

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 requests_file
 requests 
-argparse
 jsbeautifier
 lxml


### PR DESCRIPTION
`argparse` is a Python standard module.